### PR TITLE
fix: allow skip usb

### DIFF
--- a/tasks/rules.yml
+++ b/tasks/rules.yml
@@ -8,6 +8,7 @@
   register: v4_script_load_result
   failed_when: v4_script_load_result.rc != 0 or 'unknown option' in v4_script_load_result.stderr
   when: v4_script|changed
+  tags: usb
 
 - name: Save v4 rules
   shell: iptables-save -c > {{ firewall_v4_saved_rules_path }}


### PR DESCRIPTION
Allow to run on building a USB image where you can not restart services